### PR TITLE
Replacing `lubridate::date(lubridate::now())` calls with `Sys.Date()`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,11 +39,13 @@ Imports:
     rworldmap,
     settings,
     snow,
+    sf,
     sp,
     stats,
     stringr,
     utils,
-    xml2
+    xml2,
+    fasterize
 Suggests:
     curl,
     dendextend,

--- a/R/gasflares.R
+++ b/R/gasflares.R
@@ -68,7 +68,7 @@ createNlGasFlares <- function()
     
     #if the file does not exist or is older than a day download it afresh
     #not working. download.file does not seem to update mtime
-    if (!file.exists(gasFlarePageLocalName) || (lubridate::date(lubridate::now()) - lubridate::date(file.mtime(gasFlarePageLocalName)) > lubridate::as.difftime(lubridate::period("1 day"))))
+    if (!file.exists(gasFlarePageLocalName) || (Sys.Date() - lubridate::date(file.mtime(gasFlarePageLocalName)) > lubridate::as.difftime(lubridate::period("1 day"))))
     {
       utils::download.file(url = gasFlarePageHtml, destfile = gasFlarePageLocalName, method = "auto", extra = "-N")
     }

--- a/R/getnlurl.R
+++ b/R/getnlurl.R
@@ -34,7 +34,7 @@ getNlUrlOLS <- function(nlPeriod, configName=pkgOptions("configName_OLS.Y"))
   
   #if the file does not exist or is older than a day download it afresh
   #not working. download.file does not seem to update mtime
-  if (!file.exists(ntLtsPageLocalName) || (lubridate::date(lubridate::now()) - lubridate::date(file.mtime(ntLtsPageLocalName)) > lubridate::as.difftime(lubridate::period("1 day"))))
+  if (!file.exists(ntLtsPageLocalName) || (Sys.Date() - lubridate::date(file.mtime(ntLtsPageLocalName)) > lubridate::as.difftime(lubridate::period("1 day"))))
   {
     utils::download.file(url = ntLtsPageHtml, destfile = ntLtsPageLocalName, method = "auto", extra = "-N")
   }
@@ -140,7 +140,7 @@ getNlUrlVIIRS <- function(nlPeriod, tileNum, nlType, configName=pkgOptions(paste
   ntLtsPageLocalName <- file.path(getNlDir("dirNlTemp"),paste0("ntltspage", nlType, ".html"))
   
   #if the file does not exist or is older than a week download it afresh
-  if (!file.exists(ntLtsPageLocalName) || (lubridate::date(lubridate::now()) - lubridate::date(file.mtime(ntLtsPageLocalName)) > lubridate::as.difftime(lubridate::period("1 day"))) || file.size(ntLtsPageLocalName) == 0)
+  if (!file.exists(ntLtsPageLocalName) || (Sys.Date() - lubridate::date(file.mtime(ntLtsPageLocalName)) > lubridate::as.difftime(lubridate::period("1 day"))) || file.size(ntLtsPageLocalName) == 0)
   {
     utils::download.file(url = ntLtsIndexUrlVIIRS, destfile = ntLtsPageLocalName, method = "auto", extra = " -N --timestamping --no-use-server-timestamps")
   }
@@ -200,7 +200,7 @@ getNlUrl <- function(nlPeriod)
   
   #if the file does not exist or is older than a day download it afresh
   #not working. download.file does not seem to update mtime
-  if (!file.exists(ntLtsPageLocalName) || (lubridate::date(lubridate::now()) - lubridate::date(file.mtime(ntLtsPageLocalName)) > lubridate::as.difftime(lubridate::period("1 day"))))
+  if (!file.exists(ntLtsPageLocalName) || (Sys.Date() - lubridate::date(file.mtime(ntLtsPageLocalName)) > lubridate::as.difftime(lubridate::period("1 day"))))
   {
     utils::download.file(url = ntLtsPageHtml, destfile = ntLtsPageLocalName, method = "auto", extra = "-N")
   } else

--- a/R/nightlights.R
+++ b/R/nightlights.R
@@ -332,7 +332,6 @@ processNLCountry <- function(ctryCode,
       # Convert sf object to raster
 
       ctryPolyAdm0_raster <- fasterize::fasterize(sf = sf::st_as_sf(ctryPolyAdm0), raster = ctryRastCropped)
-      ctryPolyAdm0_raster <- sf::st_transform(ctryPolyAdm0_raster, raster::projection(ctryRastCropped))
       message(Sys.time(), ": Masking ")
 
       ctryRastCropped <- raster::mask(x = ctryRastCropped, mask = ctryPolyAdm0_raster)

--- a/R/nightlights.R
+++ b/R/nightlights.R
@@ -325,10 +325,18 @@ processNLCountry <- function(ctryCode,
     if (cropMaskMethod == "rast")
     {
       #RASTERIZE
-      message(Sys.time(), ": Mask using rasterize ")
+      message(Sys.time(), ": Convert to raster object using fasterize ")
       
-      ctryRastCropped <- raster::rasterize(x = ctryPolyAdm0, y = ctryRastCropped, mask=TRUE, progress="text") #crops to polygon edge & converts to raster
       
+      # Use fasterize to mask
+      # Convert sf object to raster
+
+      ctryPolyAdm0_raster <- fasterize::fasterize(sf = sf::st_as_sf(ctryPolyAdm0), raster = ctryRastCropped)
+      ctryPolyAdm0_raster <- sf::st_transform(ctryPolyAdm0_raster, raster::projection(ctryRastCropped))
+      message(Sys.time(), ": Masking ")
+
+      ctryRastCropped <- raster::mask(x = ctryRastCropped, mask = ctryPolyAdm0_raster)
+
       message(Sys.time(), ": Writing the raster to disk ")
       
       raster::writeRaster(x = ctryRastCropped,
@@ -336,6 +344,7 @@ processNLCountry <- function(ctryCode,
                           overwrite=TRUE, progress="text")
       
       message(Sys.time(), ": Crop and mask using rasterize ... Done")
+
     }
     else if (cropMaskMethod == "gdal")
     {

--- a/R/nlperiod.R
+++ b/R/nlperiod.R
@@ -203,7 +203,7 @@ getAllNlPeriods <- function(nlTypes)
       {
         startDate <- "2017-11-20"
         
-        nlYrMthDys <- gsub("-", "", seq(as.Date(startDate), as.Date(date(), "%c"), by = "day"))
+        nlYrMthDys <- gsub("-", "", seq(as.Date(startDate), as.Date(Sys.Date(), "%c"), by = "day"))
         
         return (nlYrMthDys)
       }
@@ -211,7 +211,7 @@ getAllNlPeriods <- function(nlTypes)
       {
         startDate <- "2012-04-01"
         
-        nlYrMths <- substr(gsub("-", "", seq(as.Date(startDate), as.Date(date(), "%c"), by = "month")), 1, 6)
+        nlYrMths <- substr(gsub("-", "", seq(as.Date(startDate), as.Date(Sys.Date(), "%c"), by = "month")), 1, 6)
     
         return (nlYrMths)
       }
@@ -219,7 +219,7 @@ getAllNlPeriods <- function(nlTypes)
       {
         startDate <- "2012-04-01"
         
-        nlYrs <- substr(gsub("-", "", seq(as.Date(startDate), as.Date(date(), "%c"), by = "year")), 1, 4)
+        nlYrs <- substr(gsub("-", "", seq(as.Date(startDate), as.Date(Sys.Date(), "%c"), by = "year")), 1, 4)
         
         return (nlYrs)
       }


### PR DESCRIPTION
Hello.

I have noticed a code-breaking functionality in `nlperiod.R::getAllNlPeriods()`.

Now `seq(as.Date(startDate), as.Date(date(), "%c"), by = "month")` returns NA on some locales (also notice missing `lubridate::`). In this PR I have simplified it to `seq(as.Date(startDate), as.Date(Sys.Date(), "%c"), by = "month")` to make sure it is not locale-dependent.

I have also replaced all `lubridate::date(lubridate::now())` with `Sys.Date()`.